### PR TITLE
(fix) normalise line endings before processing subtitle data

### DIFF
--- a/parse-srt.js
+++ b/parse-srt.js
@@ -2,7 +2,8 @@
 
 module.exports = srtData => {
 	const a = [];
-	const lines = srtData.split('\n');
+	const normalizedSrtData = srtData.replace(/\r\n/g, '\n');
+	const lines = normalizedSrtData.split('\n');
 	const len = lines.length;
 
 	let o = {

--- a/test/fixtures/subtitles_windows.srt
+++ b/test/fixtures/subtitles_windows.srt
@@ -1,0 +1,18 @@
+1
+00:00:24,396 --> 00:00:28,121
+So I first got into
+computer programming when
+
+2
+00:00:28,121 --> 00:00:30,505
+my family got a Commodore 64.
+
+3
+00:00:30,505 --> 00:00:34,459
+I was nine years old,
+and I was basically just
+
+4
+00:00:34,459 --> 00:00:36,555
+put in front of the
+computer, turned it on

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,16 @@ test('converts srt to obj', async t => {
 	t.is(firstEntry.text, 'Line one');
 });
 
+test('converts windows srt to obj', async t => {
+	const data = await fn(path.resolve('./fixtures/subtitles_windows.srt'));
+
+	const firstentry = data[1];
+	t.is(firstentry.index, '2');
+	t.is(firstentry.start, '00:00:28,121');
+	t.is(firstentry.end, '00:00:30,505');
+	t.is(firstentry.text, 'my family got a Commodore 64.');
+});
+
 test('grabs multiline subs', async t => {
 	const data = await fn(path.resolve('./fixtures/subtitles.srt'));
 
@@ -62,3 +72,4 @@ test.cb('every entry has an index, text, start, end, timestamp', t => {
 		t.end();
 	});
 });
+


### PR DESCRIPTION
Hi there!

Thanks for writing it this library! 😄 Parsing text files is tricky work so I appreciate being able to use this package.

I ran into a snag where my srt objects were failing to have index props added after the first index/subtitle.
Turns out trimming the previous line within the index conditional fixed this for me, and makes the checking a little more robust. See the code change for what I mean.

Tests are still passing locally.

Thanks for considering this pull request! 🙇‍♀️ 
